### PR TITLE
ci: Additionally publish public image to ghcr.io

### DIFF
--- a/.github/workflows/head-build.yml
+++ b/.github/workflows/head-build.yml
@@ -71,20 +71,24 @@ jobs:
       - name: Re-tag the static head image using the rolling tag
         env:
           FULL_IMAGE_URL: ${{ env.PUBLIC_REGISTRY }}/${{ vars.REPO || github.repository_owner }}/${{ vars.IMAGE_NAME || 'kuberlr-kubectl' }}
+          STATIC_TAG: ${{ needs.prebuild-env.outputs.branch_static_tag }}
+          LATEST_TAG: ${{ needs.prebuild-env.outputs.branch_tag }}
         run: |
           VERSION="1.2.0"
           curl -LO "https://github.com/oras-project/oras/releases/download/v${VERSION}/oras_${VERSION}_linux_amd64.tar.gz"
           mkdir -p oras-install/
           tar -zxf oras_${VERSION}_*.tar.gz -C oras-install/
-          oras-install/oras copy ${{ env.FULL_IMAGE_URL }}:${{ needs.prebuild-env.outputs.branch_static_tag }} ${{ env.FULL_IMAGE_URL }}:${{ needs.prebuild-env.outputs.branch_tag }}
+          oras-install/oras copy ${{ env.FULL_IMAGE_URL }}:${{ env.STATIC_TAG }} ${{ env.FULL_IMAGE_URL }}:${{ env.LATEST_TAG }}
 
-      - name: Re-tag the static head image to ghcr.io/${{ github.repository_owner }}
+      - name: Re-tag the image tags to ghcr.io/${{ github.repository_owner }}
         env:
           FULL_IMAGE_URL: ${{ env.PUBLIC_REGISTRY }}/${{ vars.REPO || github.repository_owner }}/${{ vars.IMAGE_NAME || 'kuberlr-kubectl' }}
+          STATIC_TAG: ${{ needs.prebuild-env.outputs.branch_static_tag }}
+          LATEST_TAG: ${{ needs.prebuild-env.outputs.branch_tag }}
           FULL_IMAGE_GHCR_URL: ghcr.io/${{ github.repository_owner }}/${{ vars.IMAGE_NAME || 'kuberlr-kubectl' }}
         run: |
           VERSION="1.2.0"
           curl -LO "https://github.com/oras-project/oras/releases/download/v${VERSION}/oras_${VERSION}_linux_amd64.tar.gz"
           mkdir -p oras-install/
           tar -zxf oras_${VERSION}_*.tar.gz -C oras-install/
-          oras-install/oras copy ${{ env.FULL_IMAGE_URL }}:${{ needs.prebuild-env.outputs.branch_static_tag }} ${{ env.FULL_IMAGE_GHCR_URL }}:${{ needs.prebuild-env.outputs.branch_tag }}
+          oras-install/oras copy ${{ env.FULL_IMAGE_URL }}:${{ env.STATIC_TAG }} ${{ env.FULL_IMAGE_GHCR_URL }}:${{ env.STATIC_TAG }},${{ env.LATEST_TAG }}

--- a/.github/workflows/head-build.yml
+++ b/.github/workflows/head-build.yml
@@ -1,4 +1,4 @@
-name : Branch head Prerelease Images
+name: Branch head Prerelease Images
 
 on:
   push:
@@ -37,6 +37,7 @@ jobs:
       # write is needed for:
       # - OIDC for cosign's use in ecm-distro-tools/publish-image.
       # - Read vault secrets in rancher-eio/read-vault-secrets.
+      # - Publish image to ghcr.io
       id-token: write
 
     runs-on: ubuntu-latest
@@ -76,3 +77,14 @@ jobs:
           mkdir -p oras-install/
           tar -zxf oras_${VERSION}_*.tar.gz -C oras-install/
           oras-install/oras copy ${{ env.FULL_IMAGE_URL }}:${{ needs.prebuild-env.outputs.branch_static_tag }} ${{ env.FULL_IMAGE_URL }}:${{ needs.prebuild-env.outputs.branch_tag }}
+
+      - name: Re-tag the static head image to ghcr.io/${{ github.repository_owner }}
+        env:
+          FULL_IMAGE_URL: ${{ env.PUBLIC_REGISTRY }}/${{ vars.REPO || github.repository_owner }}/${{ vars.IMAGE_NAME || 'kuberlr-kubectl' }}
+          FULL_IMAGE_GHCR_URL: ghcr.io/${{ github.repository_owner }}/${{ vars.IMAGE_NAME || 'kuberlr-kubectl' }}
+        run: |
+          VERSION="1.2.0"
+          curl -LO "https://github.com/oras-project/oras/releases/download/v${VERSION}/oras_${VERSION}_linux_amd64.tar.gz"
+          mkdir -p oras-install/
+          tar -zxf oras_${VERSION}_*.tar.gz -C oras-install/
+          oras-install/oras copy ${{ env.FULL_IMAGE_URL }}:${{ needs.prebuild-env.outputs.branch_static_tag }} ${{ env.FULL_IMAGE_GHCR_URL }}:${{ needs.prebuild-env.outputs.branch_tag }}

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -57,3 +57,14 @@ jobs:
           public-password: ${{ env.DOCKER_PASSWORD || secrets.DOCKER_PASSWORD }}
 
           push-to-prime: false
+      
+      - name: Re-tag the image to ghcr.io/${{ github.repository_owner }}
+        env:
+          FULL_IMAGE_URL: ${{ env.PUBLIC_REGISTRY }}/${{ vars.REPO || github.repository_owner }}/${{ vars.IMAGE_NAME || 'kuberlr-kubectl' }}
+          FULL_IMAGE_GHCR_URL: ghcr.io/${{ github.repository_owner }}/${{ vars.IMAGE_NAME || 'kuberlr-kubectl' }}
+        run: |
+          VERSION="1.2.0"
+          curl -LO "https://github.com/oras-project/oras/releases/download/v${VERSION}/oras_${VERSION}_linux_amd64.tar.gz"
+          mkdir -p oras-install/
+          tar -zxf oras_${VERSION}_*.tar.gz -C oras-install/
+          oras-install/oras copy ${{ env.FULL_IMAGE_URL }}:${{ github.ref_name }} ${{ env.FULL_IMAGE_GHCR_URL }}:${{ github.ref_name }}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # rancher/kuberlr-kubectl
 A simple way to invoke the correct [kubectl](https://github.com/rancher/kubectl) version on a Rancher managed cluster using [kuberlr](https://github.com/flavio/kuberlr).
 
-Images found at: https://hub.docker.com/r/rancher/kuberlr-kubectl
+Images found at:
+
+- https://hub.docker.com/r/rancher/kuberlr-kubectl
+- https://github.com/rancher/kuberlr-kubectl/pkgs/container/kuberlr-kubectl
 
 ## Details
 This repo produces a Rancher specific version of the `flavio/kuberlr` image.


### PR DESCRIPTION
Push the public image also to ghcr.io, under https://github.com/orgs/rancher/packages.

I haven't tested the PR, as I wouldn't progress through the previous steps from my fork.


This is triggered by the desire to consume this image as part of Kubewarden, [here](https://github.com/kubewarden/helm-charts/blob/main/charts/kubewarden-controller/values.yaml#L160). Kubewarden charts follow the convention on having a value `  cattle.systemDefaultRegistry`, which we already have set as `ghcr.io` for the rest of images. Hence, continuing on serving from 1 repository alone and keeping the Rancher convention would be of help to us.