### PR TITLE
RFC Feedback Fixes

### DIFF
--- a/hack/make/deps.mk
+++ b/hack/make/deps.mk
@@ -1,16 +1,16 @@
-KUBECTL28_VERSION := v1.28.13
+KUBECTL28_VERSION := v1.28.14
 KUBECTL28_SUM_arm64 ?= $(shell curl -L "https://dl.k8s.io/release/$(KUBECTL28_VERSION)/bin/linux/arm64/kubectl.sha256")
 KUBECTL28_SUM_amd64 ?= $(shell curl -L "https://dl.k8s.io/release/$(KUBECTL28_VERSION)/bin/linux/amd64/kubectl.sha256")
 
-KUBECTL29_VERSION := v1.29.8
+KUBECTL29_VERSION := v1.29.9
 KUBECTL29_SUM_arm64 ?= $(shell curl -L "https://dl.k8s.io/release/$(KUBECTL29_VERSION)/bin/linux/arm64/kubectl.sha256")
 KUBECTL29_SUM_amd64 ?= $(shell curl -L "https://dl.k8s.io/release/$(KUBECTL29_VERSION)/bin/linux/amd64/kubectl.sha256")
 
-KUBECTL30_VERSION := v1.30.4
+KUBECTL30_VERSION := v1.30.5
 KUBECTL30_SUM_arm64 ?= $(shell curl -L "https://dl.k8s.io/release/$(KUBECTL30_VERSION)/bin/linux/arm64/kubectl.sha256")
 KUBECTL30_SUM_amd64 ?= $(shell curl -L "https://dl.k8s.io/release/$(KUBECTL30_VERSION)/bin/linux/amd64/kubectl.sha256")
 
-KUBECTL31_VERSION := v1.31.0
+KUBECTL31_VERSION := v1.31.1
 KUBECTL31_SUM_arm64 ?= $(shell curl -L "https://dl.k8s.io/release/$(KUBECTL31_VERSION)/bin/linux/arm64/kubectl.sha256")
 KUBECTL31_SUM_amd64 ?= $(shell curl -L "https://dl.k8s.io/release/$(KUBECTL31_VERSION)/bin/linux/amd64/kubectl.sha256")
 

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,12 +1,33 @@
 ARG BCI_VERSION=15.6
-FROM --platform=$BUILDPLATFORM registry.suse.com/bci/bci-base:${BCI_VERSION} AS build
+FROM ghcr.io/flavio/kuberlr:v0.5.2 AS kuberlr
+FROM registry.suse.com/bci/bci-busybox:${BCI_VERSION} AS final
+FROM registry.suse.com/bci/bci-base:${BCI_VERSION} AS zypper
 
 ARG TARGETPLATFORM
 ARG TARGETARCH
 
+# Creates the based dir for the target image, and hydrates it with the
+# original contents of the final image.
+RUN mkdir /chroot
+COPY --from=final / /chroot/
+
+# The final image does not contain zypper, --installroot is used to
+# install all artefacts within a dir (/chroot) that can then be copied
+# over to a scratch image.
+RUN zypper --non-interactive refresh && \
+    zypper --installroot /chroot -n rm busybox-vi busybox-links && \
+    zypper --installroot /chroot -n in bash-completion && \
+    zypper --installroot /chroot clean -a && \
+    rm -rf /chroot/var/cache/zypp/* /chroot/var/log/zypp/* /chroot/etc/zypp/
+
+# Pull in kuberlr bin and home dir (pre configured .kubrlr)
+COPY --from=kuberlr /bin/kuberlr /chroot/bin/
+RUN cd /chroot/bin && ln -s ./kuberlr ./kubectl
+COPY --from=kuberlr /home/kuberlr /chroot/home/kuberlr
+RUN sed -i 's/AllowDownload = true/AllowDownload = false/' /chroot/home/kuberlr/.kuberlr/kuberlr.conf
+
 WORKDIR /tmp
 
-# Define build arguments
 ARG KUBECTL_VERSION_INFO
 
 SHELL ["/bin/bash", "-c"]
@@ -33,9 +54,16 @@ RUN set -fx; versions=($KUBECTL_VERSION_INFO); \
         echo "${KUBE_SUM} ${kubectl_target}" | sha256sum -c -; \
     done
 
-FROM ghcr.io/flavio/kuberlr:v0.5.2
+RUN cp /tmp/kubectl* /chroot/usr/bin/
 
-COPY --from=build /tmp/kubectl* /usr/bin/
+RUN useradd -u 1000 -U kuberlr \
+    && cp /etc/passwd /chroot/etc/passwd \
+    && cp /etc/group /chroot/etc/group \
+    && chown -R 1000:1000 /chroot/home/kuberlr
+
+FROM scratch
+
+COPY --from=zypper /chroot /
 
 USER kuberlr
 WORKDIR /home/kuberlr


### PR DESCRIPTION
Per title, this corrects an oversight I left in place where I was simply adding kubectl binaries to the base kuberlr image. However the optimal method was to fetch the kuberlr binary and add it into an image we compose. So the end result is a lot more like what we do in `rancher/kubectl` and `rancher/shell` today - which was always the end goal.

Also I bumped the kubectl versions that have been updated since the RFC review process started. Long term these will be bumped by renovate or similar automations.