### PR TITLE
feat: Use default `AllowDownload = true` config

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -24,7 +24,6 @@ RUN zypper --non-interactive refresh && \
 COPY --from=kuberlr /bin/kuberlr /chroot/bin/
 RUN cd /chroot/bin && ln -s ./kuberlr ./kubectl
 COPY --from=kuberlr /home/kuberlr /chroot/home/kuberlr
-RUN sed -i 's/AllowDownload = true/AllowDownload = false/' /chroot/home/kuberlr/.kuberlr/kuberlr.conf
 
 WORKDIR /tmp
 


### PR DESCRIPTION
This PR removes the custom configuration of `AllowDownload = false` to have the default of `true`.
This means the image will keep shipping the configured kubectl versions in the cache, but will also work if targetting different Kubernetes versions. 