### PR TITLE
Add a `kubectl` group to renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,7 +5,7 @@
   "baseBranches": [
     "renovate-test"
   ],
-  "prHourlyLimit": 12,
+  "prHourlyLimit": 24,
   "packageRules": [
     {
       "description": "Using allowedVersions ensures that the upstream range does not block patch bumps.",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,8 +3,6 @@
     "github>rancher/renovate-config#release"
   ],
   "baseBranches": [
-    "main",
-    "/^release\\/v[0-9]+.x/",
     "renovate-test"
   ],
   "prHourlyLimit": 12,

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -34,6 +34,13 @@
       "matchManagers": [
         "dockerfile"
       ]
+    },
+    {
+      "groupName": "Kubectl Dep Versions",
+      "groupSlug": "kubectl-bumps",
+      "matchDepNames": [
+        "kubernetes/kubernetes"
+      ]
     }
   ],
   "customManagers": [

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,7 +4,8 @@
   ],
   "baseBranches": [
     "main",
-    "/^release\\/v[0-9]+.x/"
+    "/^release\\/v[0-9]+.x/",
+    "renovate-test"
   ],
   "prHourlyLimit": 12,
   "packageRules": [


### PR DESCRIPTION
This groups all the `kubectl` bumps into a single PR like:

- https://github.com/rancher/kuberlr-kubectl/pull/71

Instead of:
- https://github.com/rancher/kuberlr-kubectl/pull/61
- https://github.com/rancher/kuberlr-kubectl/pull/62
- https://github.com/rancher/kuberlr-kubectl/pull/63